### PR TITLE
fix: unpkg script/css CORS/MIME errors in swaggerUIPlugin.ts

### DIFF
--- a/src/swaggerUIPlugin.ts
+++ b/src/swaggerUIPlugin.ts
@@ -34,11 +34,11 @@ const swaggerUI =
                   content="SwaggerUI"
                 />
                 <title>SwaggerUI</title>
-                <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.16.1/swagger-ui.css" />
+                <link href=" https://cdn.jsdelivr.net/npm/swagger-ui@5.20.0/dist/swagger-ui.min.css " rel="stylesheet">
               </head>
               <body>
               <div id="swagger-ui"></div>
-              <script src="https://unpkg.com/swagger-ui-dist@4.16.1/swagger-ui-bundle.js" crossorigin></script>
+              <script src=" https://cdn.jsdelivr.net/npm/swagger-ui@5.20.0/dist/swagger-ui-bundle.min.js "></script>
               <script>
                 window.onload = () => {
                   window.ui = SwaggerUIBundle({


### PR DESCRIPTION
When using this plugin with a dummy domain and SSL (to be able to use HTTPS on browser), we get CORS and MIME type errors due to `unpkg`:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://unpkg.com/swagger-ui-dist@4.16.1/swagger-ui-bundle.js. (Reason: CORS request did not succeed). Status code: (null).
```

```
The resource from “https://unpkg.com/swagger-ui-dist@4.16.1/swagger-ui.css” was blocked due to MIME type (“”) mismatch (X-Content-Type-Options: nosniff).
```

These changes fix the errors by replacing `unpkg` with `jsdelivr`.

As a bonus, this also updates Swagger UI to the latest version! 🥳