### PR TITLE
fix: Empty paths property in version 3.1

### DIFF
--- a/src/openapi/generators.ts
+++ b/src/openapi/generators.ts
@@ -658,8 +658,10 @@ export const generateV31Spec = async (
     servers: [{ url: `${req.protocol}//${req.headers.get('host')}` }],
     paths: Object.assign(
       {},
-      ...Object.values(req.payload.collections).map(generateCollectionOperations),
-      ...req.payload.globals.config.map(generateGlobalOperations),
+      ...(await Promise.all(
+        Object.values(req.payload.collections).map(generateCollectionOperations),
+      )),
+      ...(await Promise.all(req.payload.globals.config.map(generateGlobalOperations))),
     ),
     components: {
       securitySchemes: generateSecuritySchemes(options.authEndpoint),


### PR DESCRIPTION
The `paths` property of the version 3.1 spec is empty, because the `generateCollectionOperations` and `generateGlobalOperations` function aren't awaited.