### PR TITLE
fix: Handle empty string in the upperFirst utility function

### DIFF
--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,2 +1,4 @@
-export const upperFirst = (value: string) => value[0].toUpperCase() + value.slice(1)
+export const upperFirst = (value: string) =>
+  value.length > 0 ? value[0].toUpperCase() + value.slice(1) : ''
+
 export const camelize = (value: string) => value.split(/\s+/).map(upperFirst).join('')


### PR DESCRIPTION
- closes #41
