### PR TITLE
feat: add locale and depth parameters to POST endpoints

### DIFF
--- a/src/openapi/generators.ts
+++ b/src/openapi/generators.ts
@@ -27,6 +27,11 @@ const baseQueryParams: Array<OpenAPIV3.ParameterObject & OpenAPIV3_1.ParameterOb
   { in: 'query', name: 'fallback-locale', schema: { type: 'string' } },
 ]
 
+const createQueryParams: Array<OpenAPIV3.ParameterObject & OpenAPIV3_1.ParameterObject> = [
+  { in: 'query', name: 'depth', schema: { type: 'number' } },
+  { in: 'query', name: 'locale', schema: { type: 'string' } },
+]
+
 async function jsonSchemaToOpenapiSchema(schema: JSONSchema4): Promise<OpenAPIV3.Document> {
   return await (_jsonSchemaToOpenapiSchema as any)(schema)
 }
@@ -418,6 +423,7 @@ const generateCollectionOperations = async (
       post: {
         summary: `Create a new ${singular}`,
         tags,
+        parameters: createQueryParams,
         requestBody: composeRef('requestBodies', singular),
         responses: {
           201: composeRef('responses', singular, { prefix: 'New' }),

--- a/test/__snapshots__/openapi-generators.test.ts.snap
+++ b/test/__snapshots__/openapi-generators.test.ts.snap
@@ -1801,6 +1801,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
         },
@@ -2008,6 +2024,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
         },
@@ -2213,6 +2245,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
         },
@@ -2430,6 +2478,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/UsersRequestBody",
         },
@@ -4868,6 +4932,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PageRequestBody",
         },
@@ -5073,6 +5153,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
         },
@@ -5280,6 +5376,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
         },
@@ -5485,6 +5597,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
         },
@@ -5702,6 +5830,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/UsersRequestBody",
         },
@@ -8096,6 +8240,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/EventRequestBody",
         },
@@ -8301,6 +8461,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
         },
@@ -8508,6 +8684,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
         },
@@ -8713,6 +8905,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
         },
@@ -8930,6 +9138,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/UsersRequestBody",
         },
@@ -10888,6 +11112,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
         },
@@ -11095,6 +11335,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
         },
@@ -11300,6 +11556,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
         },
@@ -11517,6 +11789,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/UserRequestBody",
         },
@@ -13780,6 +14068,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
         },
@@ -13987,6 +14291,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
         },
@@ -14192,6 +14512,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
         },
@@ -14397,6 +14733,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PostRequestBody",
         },
@@ -14614,6 +14966,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
       },
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/UsersRequestBody",
         },


### PR DESCRIPTION
## Description
Add locale and depth query parameters to POST endpoints in OpenAPI documentation.

## Changes
- Added `createQueryParams` for POST operations (includes depth, locale)
- Kept `baseQueryParams` for GET/PATCH/DELETE (includes fallback-locale)
- POST endpoints now correctly document available query parameters

## Rationale
- `locale` and `depth` are valid for POST requests (control created document locale and response depth)
- `fallback-locale` is not applicable to POST since it creates new data (no existing data to fall back to)
