### PR TITLE
feat: respect default ID type from db adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
     "@payloadcms/db-mongodb": "^3.53.0",
+    "@payloadcms/db-sqlite": "^3.58.0",
     "@payloadcms/next": "^3.53.0",
     "@payloadcms/richtext-lexical": "^3.53.0",
     "@types/react": "19.1.11",

--- a/src/openapi/generators.ts
+++ b/src/openapi/generators.ts
@@ -93,7 +93,7 @@ const generateSchemaObject = (config: SanitizedConfig, collection: Collection): 
     config,
     removeInterfaceNames(collection.config), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
     new Map(),
-    'text',
+    config.db.defaultIDType,
     undefined,
   )
 
@@ -137,7 +137,7 @@ const generateRequestBodySchema = (
     config,
     removeInterfaceNames(collection.config), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
     new Map(),
-    'text',
+    config.db.defaultIDType,
     undefined,
   )
 
@@ -541,7 +541,7 @@ const generateGlobalSchemas = (
     config,
     removeInterfaceNames(global),
     new Map(),
-    'text',
+    config.db.defaultIDType,
     undefined,
   )
 

--- a/test/__snapshots__/openapi-generators.test.ts.snap
+++ b/test/__snapshots__/openapi-generators.test.ts.snap
@@ -16088,3 +16088,3362 @@ exports[`openapi generators > handles non-default collection 1`] = `
   ],
 }
 `;
+
+exports[`openapi generators > respects default ID type from db adapter 1`] = `
+{
+  "components": {
+    "requestBodies": {
+      "PayloadLockedDocumentPatchRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "document": {
+                  "description": "ID of the posts/users",
+                  "type": "string",
+                },
+                "globalSlug": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "user": {
+                  "description": "ID of the users",
+                  "type": "string",
+                },
+              },
+              "required": [],
+              "title": "PayloadLockedDocument",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Locked Document",
+      },
+      "PayloadLockedDocumentRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "document": {
+                  "description": "ID of the posts/users",
+                  "type": "string",
+                },
+                "globalSlug": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "user": {
+                  "description": "ID of the users",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "user",
+              ],
+              "title": "PayloadLockedDocument",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Locked Document",
+      },
+      "PayloadMigrationPatchRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "batch": {
+                  "nullable": true,
+                  "type": "number",
+                },
+                "name": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [],
+              "title": "PayloadMigration",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Migration",
+      },
+      "PayloadMigrationRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "batch": {
+                  "nullable": true,
+                  "type": "number",
+                },
+                "name": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [],
+              "title": "PayloadMigration",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Migration",
+      },
+      "PayloadPreferencePatchRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "user": {
+                  "description": "ID of the users",
+                  "type": "string",
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                    },
+                    {
+                      "items": {},
+                      "type": "array",
+                    },
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "type": "boolean",
+                    },
+                  ],
+                  "nullable": true,
+                },
+              },
+              "required": [],
+              "title": "PayloadPreference",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Preference",
+      },
+      "PayloadPreferenceRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "user": {
+                  "description": "ID of the users",
+                  "type": "string",
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                    },
+                    {
+                      "items": {},
+                      "type": "array",
+                    },
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "type": "boolean",
+                    },
+                  ],
+                  "nullable": true,
+                },
+              },
+              "required": [
+                "user",
+              ],
+              "title": "PayloadPreference",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Preference",
+      },
+      "PostPatchRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "title": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [],
+              "title": "Post",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Post",
+      },
+      "PostRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "title": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [],
+              "title": "Post",
+              "type": "object",
+            },
+          },
+        },
+        "description": "Post",
+      },
+      "UsersPatchRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "email": {
+                  "type": "string",
+                },
+                "password": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "sessions": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "createdAt": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "expiresAt": {
+                        "type": "string",
+                      },
+                      "id": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "expiresAt",
+                    ],
+                    "type": "object",
+                  },
+                  "nullable": true,
+                  "type": "array",
+                },
+              },
+              "required": [],
+              "title": "User",
+              "type": "object",
+            },
+          },
+        },
+        "description": "users",
+      },
+      "UsersRequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "email": {
+                  "type": "string",
+                },
+                "password": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "sessions": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "createdAt": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "expiresAt": {
+                        "type": "string",
+                      },
+                      "id": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "expiresAt",
+                    ],
+                    "type": "object",
+                  },
+                  "nullable": true,
+                  "type": "array",
+                },
+              },
+              "required": [
+                "email",
+              ],
+              "title": "User",
+              "type": "object",
+            },
+          },
+        },
+        "description": "users",
+      },
+    },
+    "responses": {
+      "NewPayloadLockedDocumentResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "doc": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadLockedDocument",
+                    },
+                    {
+                      "properties": {
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "message",
+                "doc",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Locked Document object",
+      },
+      "NewPayloadMigrationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "doc": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadMigration",
+                    },
+                    {
+                      "properties": {
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "message",
+                "doc",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Migration object",
+      },
+      "NewPayloadPreferenceResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "doc": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadPreference",
+                    },
+                    {
+                      "properties": {
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "message",
+                "doc",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "Payload Preference object",
+      },
+      "NewPostResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "doc": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Post",
+                    },
+                    {
+                      "properties": {
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "message",
+                "doc",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "Post object",
+      },
+      "NewUsersResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "doc": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Users",
+                    },
+                    {
+                      "properties": {
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "message",
+                "doc",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "users object",
+      },
+      "PayloadLockedDocumentListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "docs": {
+                  "items": {
+                    "$ref": "#/components/schemas/PayloadLockedDocument",
+                  },
+                  "type": "array",
+                },
+                "hasNextPage": {
+                  "type": "boolean",
+                },
+                "hasPrevPage": {
+                  "type": "boolean",
+                },
+                "limit": {
+                  "type": "integer",
+                },
+                "nextPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "page": {
+                  "type": "integer",
+                },
+                "pagingCounter": {
+                  "type": "integer",
+                },
+                "prevPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "totalDocs": {
+                  "type": "integer",
+                },
+                "totalPages": {
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "docs",
+                "totalDocs",
+                "limit",
+                "totalPages",
+                "page",
+                "pagingCounter",
+                "hasPrevPage",
+                "hasNextPage",
+                "prevPage",
+                "nextPage",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "List of Payload Locked Documents",
+      },
+      "PayloadLockedDocumentNotFoundResponse": {
+        "content": {},
+        "description": "Payload Locked Document not found",
+      },
+      "PayloadLockedDocumentResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PayloadLockedDocument",
+            },
+          },
+        },
+        "description": "Payload Locked Document object",
+      },
+      "PayloadMigrationListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "docs": {
+                  "items": {
+                    "$ref": "#/components/schemas/PayloadMigration",
+                  },
+                  "type": "array",
+                },
+                "hasNextPage": {
+                  "type": "boolean",
+                },
+                "hasPrevPage": {
+                  "type": "boolean",
+                },
+                "limit": {
+                  "type": "integer",
+                },
+                "nextPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "page": {
+                  "type": "integer",
+                },
+                "pagingCounter": {
+                  "type": "integer",
+                },
+                "prevPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "totalDocs": {
+                  "type": "integer",
+                },
+                "totalPages": {
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "docs",
+                "totalDocs",
+                "limit",
+                "totalPages",
+                "page",
+                "pagingCounter",
+                "hasPrevPage",
+                "hasNextPage",
+                "prevPage",
+                "nextPage",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "List of Payload Migrations",
+      },
+      "PayloadMigrationNotFoundResponse": {
+        "content": {},
+        "description": "Payload Migration not found",
+      },
+      "PayloadMigrationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PayloadMigration",
+            },
+          },
+        },
+        "description": "Payload Migration object",
+      },
+      "PayloadPreferenceListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "docs": {
+                  "items": {
+                    "$ref": "#/components/schemas/PayloadPreference",
+                  },
+                  "type": "array",
+                },
+                "hasNextPage": {
+                  "type": "boolean",
+                },
+                "hasPrevPage": {
+                  "type": "boolean",
+                },
+                "limit": {
+                  "type": "integer",
+                },
+                "nextPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "page": {
+                  "type": "integer",
+                },
+                "pagingCounter": {
+                  "type": "integer",
+                },
+                "prevPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "totalDocs": {
+                  "type": "integer",
+                },
+                "totalPages": {
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "docs",
+                "totalDocs",
+                "limit",
+                "totalPages",
+                "page",
+                "pagingCounter",
+                "hasPrevPage",
+                "hasNextPage",
+                "prevPage",
+                "nextPage",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "List of Payload Preferences",
+      },
+      "PayloadPreferenceNotFoundResponse": {
+        "content": {},
+        "description": "Payload Preference not found",
+      },
+      "PayloadPreferenceResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PayloadPreference",
+            },
+          },
+        },
+        "description": "Payload Preference object",
+      },
+      "PostListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "docs": {
+                  "items": {
+                    "$ref": "#/components/schemas/Post",
+                  },
+                  "type": "array",
+                },
+                "hasNextPage": {
+                  "type": "boolean",
+                },
+                "hasPrevPage": {
+                  "type": "boolean",
+                },
+                "limit": {
+                  "type": "integer",
+                },
+                "nextPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "page": {
+                  "type": "integer",
+                },
+                "pagingCounter": {
+                  "type": "integer",
+                },
+                "prevPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "totalDocs": {
+                  "type": "integer",
+                },
+                "totalPages": {
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "docs",
+                "totalDocs",
+                "limit",
+                "totalPages",
+                "page",
+                "pagingCounter",
+                "hasPrevPage",
+                "hasNextPage",
+                "prevPage",
+                "nextPage",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "List of Posts",
+      },
+      "PostNotFoundResponse": {
+        "content": {},
+        "description": "Post not found",
+      },
+      "PostResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Post",
+            },
+          },
+        },
+        "description": "Post object",
+      },
+      "UsersListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "docs": {
+                  "items": {
+                    "$ref": "#/components/schemas/Users",
+                  },
+                  "type": "array",
+                },
+                "hasNextPage": {
+                  "type": "boolean",
+                },
+                "hasPrevPage": {
+                  "type": "boolean",
+                },
+                "limit": {
+                  "type": "integer",
+                },
+                "nextPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "page": {
+                  "type": "integer",
+                },
+                "pagingCounter": {
+                  "type": "integer",
+                },
+                "prevPage": {
+                  "nullable": true,
+                  "type": "integer",
+                },
+                "totalDocs": {
+                  "type": "integer",
+                },
+                "totalPages": {
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "docs",
+                "totalDocs",
+                "limit",
+                "totalPages",
+                "page",
+                "pagingCounter",
+                "hasPrevPage",
+                "hasNextPage",
+                "prevPage",
+                "nextPage",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "description": "List of users",
+      },
+      "UsersNotFoundResponse": {
+        "content": {},
+        "description": "users not found",
+      },
+      "UsersResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Users",
+            },
+          },
+        },
+        "description": "users object",
+      },
+    },
+    "schemas": {
+      "PayloadLockedDocument": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string",
+          },
+          "document": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "nullable": true,
+                "properties": {
+                  "relationTo": {
+                    "enum": [
+                      "posts",
+                    ],
+                  },
+                  "value": {
+                    "oneOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/Post",
+                      },
+                    ],
+                  },
+                },
+                "required": [
+                  "value",
+                  "relationTo",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": false,
+                "nullable": true,
+                "properties": {
+                  "relationTo": {
+                    "enum": [
+                      "users",
+                    ],
+                  },
+                  "value": {
+                    "oneOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/Users",
+                      },
+                    ],
+                  },
+                },
+                "required": [
+                  "value",
+                  "relationTo",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "globalSlug": {
+            "nullable": true,
+            "type": "string",
+          },
+          "id": {
+            "type": "number",
+          },
+          "updatedAt": {
+            "type": "string",
+          },
+          "user": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "relationTo": {
+                    "enum": [
+                      "users",
+                    ],
+                  },
+                  "value": {
+                    "oneOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/Users",
+                      },
+                    ],
+                  },
+                },
+                "required": [
+                  "value",
+                  "relationTo",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+        },
+        "required": [
+          "id",
+          "user",
+          "updatedAt",
+          "createdAt",
+        ],
+        "title": "Payload Locked Document",
+        "type": "object",
+      },
+      "PayloadLockedDocumentQueryOperations": {
+        "properties": {
+          "createdAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "globalSlug": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "updatedAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "title": "Payload Locked Document query operations",
+        "type": "object",
+      },
+      "PayloadLockedDocumentQueryOperationsAnd": {
+        "properties": {
+          "and": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "and",
+        ],
+        "title": "Payload Locked Document query conjunction",
+        "type": "object",
+      },
+      "PayloadLockedDocumentQueryOperationsOr": {
+        "properties": {
+          "or": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "or",
+        ],
+        "title": "Payload Locked Document query disjunction",
+        "type": "object",
+      },
+      "PayloadMigration": {
+        "additionalProperties": false,
+        "properties": {
+          "batch": {
+            "nullable": true,
+            "type": "number",
+          },
+          "createdAt": {
+            "type": "string",
+          },
+          "id": {
+            "type": "number",
+          },
+          "name": {
+            "nullable": true,
+            "type": "string",
+          },
+          "updatedAt": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "updatedAt",
+          "createdAt",
+        ],
+        "title": "Payload Migration",
+        "type": "object",
+      },
+      "PayloadMigrationQueryOperations": {
+        "properties": {
+          "batch": {
+            "properties": {
+              "equals": {
+                "type": "number",
+              },
+              "greater_than": {
+                "type": "number",
+              },
+              "greater_than_equal": {
+                "type": "number",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "type": "number",
+              },
+              "less_than_equal": {
+                "type": "number",
+              },
+              "not_equals": {
+                "type": "number",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "createdAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "name": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "updatedAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "title": "Payload Migration query operations",
+        "type": "object",
+      },
+      "PayloadMigrationQueryOperationsAnd": {
+        "properties": {
+          "and": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "and",
+        ],
+        "title": "Payload Migration query conjunction",
+        "type": "object",
+      },
+      "PayloadMigrationQueryOperationsOr": {
+        "properties": {
+          "or": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadMigrationQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "or",
+        ],
+        "title": "Payload Migration query disjunction",
+        "type": "object",
+      },
+      "PayloadPreference": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string",
+          },
+          "id": {
+            "type": "number",
+          },
+          "key": {
+            "nullable": true,
+            "type": "string",
+          },
+          "updatedAt": {
+            "type": "string",
+          },
+          "user": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "relationTo": {
+                    "enum": [
+                      "users",
+                    ],
+                  },
+                  "value": {
+                    "oneOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/Users",
+                      },
+                    ],
+                  },
+                },
+                "required": [
+                  "value",
+                  "relationTo",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "object",
+              },
+              {
+                "items": {},
+                "type": "array",
+              },
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+              {
+                "type": "boolean",
+              },
+            ],
+            "nullable": true,
+          },
+        },
+        "required": [
+          "id",
+          "user",
+          "updatedAt",
+          "createdAt",
+        ],
+        "title": "Payload Preference",
+        "type": "object",
+      },
+      "PayloadPreferenceQueryOperations": {
+        "properties": {
+          "createdAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "key": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "updatedAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "title": "Payload Preference query operations",
+        "type": "object",
+      },
+      "PayloadPreferenceQueryOperationsAnd": {
+        "properties": {
+          "and": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "and",
+        ],
+        "title": "Payload Preference query conjunction",
+        "type": "object",
+      },
+      "PayloadPreferenceQueryOperationsOr": {
+        "properties": {
+          "or": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "or",
+        ],
+        "title": "Payload Preference query disjunction",
+        "type": "object",
+      },
+      "Post": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string",
+          },
+          "id": {
+            "type": "number",
+          },
+          "title": {
+            "nullable": true,
+            "type": "string",
+          },
+          "updatedAt": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "updatedAt",
+          "createdAt",
+        ],
+        "title": "Post",
+        "type": "object",
+      },
+      "PostQueryOperations": {
+        "properties": {
+          "createdAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "title": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "updatedAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "title": "Post query operations",
+        "type": "object",
+      },
+      "PostQueryOperationsAnd": {
+        "properties": {
+          "and": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PostQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PostQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PostQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "and",
+        ],
+        "title": "Post query conjunction",
+        "type": "object",
+      },
+      "PostQueryOperationsOr": {
+        "properties": {
+          "or": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PostQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/PostQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/PostQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "or",
+        ],
+        "title": "Post query disjunction",
+        "type": "object",
+      },
+      "Users": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string",
+          },
+          "email": {
+            "type": "string",
+          },
+          "id": {
+            "type": "number",
+          },
+          "password": {
+            "nullable": true,
+            "type": "string",
+          },
+          "sessions": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "createdAt": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "expiresAt": {
+                  "type": "string",
+                },
+                "id": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "id",
+                "expiresAt",
+              ],
+              "type": "object",
+            },
+            "nullable": true,
+            "type": "array",
+          },
+          "updatedAt": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "updatedAt",
+          "createdAt",
+          "email",
+        ],
+        "title": "users",
+        "type": "object",
+      },
+      "UsersQueryOperations": {
+        "properties": {
+          "createdAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "email": {
+            "properties": {
+              "contains": {
+                "format": "email",
+                "type": "string",
+              },
+              "equals": {
+                "format": "email",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "email",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "hash": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "lockUntil": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "loginAttempts": {
+            "properties": {
+              "equals": {
+                "type": "number",
+              },
+              "greater_than": {
+                "type": "number",
+              },
+              "greater_than_equal": {
+                "type": "number",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "type": "number",
+              },
+              "less_than_equal": {
+                "type": "number",
+              },
+              "not_equals": {
+                "type": "number",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "resetPasswordExpiration": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "resetPasswordToken": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "salt": {
+            "properties": {
+              "contains": {
+                "type": "string",
+              },
+              "equals": {
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "like": {
+                "type": "string",
+              },
+              "not_equals": {
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "updatedAt": {
+            "properties": {
+              "equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "greater_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "in": {
+                "type": "string",
+              },
+              "less_than": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "less_than_equal": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_equals": {
+                "format": "date-time",
+                "type": "string",
+              },
+              "not_in": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "title": "users query operations",
+        "type": "object",
+      },
+      "UsersQueryOperationsAnd": {
+        "properties": {
+          "and": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "and",
+        ],
+        "title": "users query conjunction",
+        "type": "object",
+      },
+      "UsersQueryOperationsOr": {
+        "properties": {
+          "or": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperations",
+                },
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperationsAnd",
+                },
+                {
+                  "$ref": "#/components/schemas/UsersQueryOperationsOr",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "or",
+        ],
+        "title": "users query disjunction",
+        "type": "object",
+      },
+      "supportedTimezones": {
+        "example": "Europe/Prague",
+        "type": "string",
+      },
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "/api//api/auth",
+          },
+        },
+        "type": "oauth2",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/payload-locked-documents": {
+      "get": {
+        "operationId": "listPayloadLockedDocuments",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "enum": [
+                "globalSlug",
+                "-globalSlug",
+                "updatedAt",
+                "-updatedAt",
+                "createdAt",
+                "-createdAt",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "where",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperations",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsAnd",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadLockedDocumentQueryOperationsOr",
+                    },
+                  ],
+                },
+              ],
+            },
+            "style": "deepObject",
+          },
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadLockedDocumentListResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Retrieve a list of Payload Locked Documents",
+        "tags": [
+          "Payload Locked Documents",
+        ],
+      },
+      "post": {
+        "operationId": "createPayloadLockedDocument",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Create a new Payload Locked Document",
+        "tags": [
+          "Payload Locked Documents",
+        ],
+      },
+    },
+    "/api/payload-locked-documents/{id}": {
+      "delete": {
+        "operationId": "deletePayloadLockedDocument",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadLockedDocumentNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Delete a Payload Locked Document",
+        "tags": [
+          "Payload Locked Documents",
+        ],
+      },
+      "get": {
+        "operationId": "findPayloadLockedDocumentById",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadLockedDocumentNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Find a Payload Locked Document by ID",
+        "tags": [
+          "Payload Locked Documents",
+        ],
+      },
+      "parameters": [
+        {
+          "in": "query",
+          "name": "depth",
+          "schema": {
+            "type": "number",
+          },
+        },
+        {
+          "in": "query",
+          "name": "locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "fallback-locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "ID of the Payload Locked Document",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+      "patch": {
+        "operationId": "updatePayloadLockedDocument",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentPatchRequestBody",
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadLockedDocumentNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Update a Payload Locked Document",
+        "tags": [
+          "Payload Locked Documents",
+        ],
+      },
+    },
+    "/api/payload-migrations": {
+      "get": {
+        "operationId": "listPayloadMigrations",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "enum": [
+                "name",
+                "-name",
+                "batch",
+                "-batch",
+                "updatedAt",
+                "-updatedAt",
+                "createdAt",
+                "-createdAt",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "where",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadMigrationQueryOperations",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadMigrationQueryOperationsAnd",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadMigrationQueryOperationsOr",
+                    },
+                  ],
+                },
+              ],
+            },
+            "style": "deepObject",
+          },
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadMigrationListResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Retrieve a list of Payload Migrations",
+        "tags": [
+          "Payload Migrations",
+        ],
+      },
+      "post": {
+        "operationId": "createPayloadMigration",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Create a new Payload Migration",
+        "tags": [
+          "Payload Migrations",
+        ],
+      },
+    },
+    "/api/payload-migrations/{id}": {
+      "delete": {
+        "operationId": "deletePayloadMigration",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadMigrationResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadMigrationNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Delete a Payload Migration",
+        "tags": [
+          "Payload Migrations",
+        ],
+      },
+      "get": {
+        "operationId": "findPayloadMigrationById",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadMigrationResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadMigrationNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Find a Payload Migration by ID",
+        "tags": [
+          "Payload Migrations",
+        ],
+      },
+      "parameters": [
+        {
+          "in": "query",
+          "name": "depth",
+          "schema": {
+            "type": "number",
+          },
+        },
+        {
+          "in": "query",
+          "name": "locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "fallback-locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "ID of the Payload Migration",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+      "patch": {
+        "operationId": "updatePayloadMigration",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationPatchRequestBody",
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadMigrationResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadMigrationNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Update a Payload Migration",
+        "tags": [
+          "Payload Migrations",
+        ],
+      },
+    },
+    "/api/payload-preferences": {
+      "get": {
+        "operationId": "listPayloadPreferences",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "enum": [
+                "key",
+                "-key",
+                "updatedAt",
+                "-updatedAt",
+                "createdAt",
+                "-createdAt",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "where",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/PayloadPreferenceQueryOperations",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsAnd",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PayloadPreferenceQueryOperationsOr",
+                    },
+                  ],
+                },
+              ],
+            },
+            "style": "deepObject",
+          },
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadPreferenceListResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Retrieve a list of Payload Preferences",
+        "tags": [
+          "Payload Preferences",
+        ],
+      },
+      "post": {
+        "operationId": "createPayloadPreference",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Create a new Payload Preference",
+        "tags": [
+          "Payload Preferences",
+        ],
+      },
+    },
+    "/api/payload-preferences/{id}": {
+      "delete": {
+        "operationId": "deletePayloadPreference",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadPreferenceNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Delete a Payload Preference",
+        "tags": [
+          "Payload Preferences",
+        ],
+      },
+      "get": {
+        "operationId": "findPayloadPreferenceById",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadPreferenceNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Find a Payload Preference by ID",
+        "tags": [
+          "Payload Preferences",
+        ],
+      },
+      "parameters": [
+        {
+          "in": "query",
+          "name": "depth",
+          "schema": {
+            "type": "number",
+          },
+        },
+        {
+          "in": "query",
+          "name": "locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "fallback-locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "ID of the Payload Preference",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+      "patch": {
+        "operationId": "updatePayloadPreference",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferencePatchRequestBody",
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PayloadPreferenceNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Update a Payload Preference",
+        "tags": [
+          "Payload Preferences",
+        ],
+      },
+    },
+    "/api/posts": {
+      "get": {
+        "operationId": "listPosts",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "enum": [
+                "title",
+                "-title",
+                "updatedAt",
+                "-updatedAt",
+                "createdAt",
+                "-createdAt",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "where",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/PostQueryOperations",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PostQueryOperationsAnd",
+                    },
+                    {
+                      "$ref": "#/components/schemas/PostQueryOperationsOr",
+                    },
+                  ],
+                },
+              ],
+            },
+            "style": "deepObject",
+          },
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PostListResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Retrieve a list of Posts",
+        "tags": [
+          "Posts",
+        ],
+      },
+      "post": {
+        "operationId": "createPost",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PostRequestBody",
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewPostResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Create a new Post",
+        "tags": [
+          "Posts",
+        ],
+      },
+    },
+    "/api/posts/{id}": {
+      "delete": {
+        "operationId": "deletePost",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PostResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PostNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Delete a Post",
+        "tags": [
+          "Posts",
+        ],
+      },
+      "get": {
+        "operationId": "findPostById",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PostResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PostNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Find a Post by ID",
+        "tags": [
+          "Posts",
+        ],
+      },
+      "parameters": [
+        {
+          "in": "query",
+          "name": "depth",
+          "schema": {
+            "type": "number",
+          },
+        },
+        {
+          "in": "query",
+          "name": "locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "fallback-locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "ID of the Post",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+      "patch": {
+        "operationId": "updatePost",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PostPatchRequestBody",
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PostResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/PostNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Update a Post",
+        "tags": [
+          "Posts",
+        ],
+      },
+    },
+    "/api/users": {
+      "get": {
+        "operationId": "listUsers",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "enum": [
+                "updatedAt",
+                "-updatedAt",
+                "createdAt",
+                "-createdAt",
+                "email",
+                "-email",
+                "resetPasswordToken",
+                "-resetPasswordToken",
+                "resetPasswordExpiration",
+                "-resetPasswordExpiration",
+                "salt",
+                "-salt",
+                "hash",
+                "-hash",
+                "loginAttempts",
+                "-loginAttempts",
+                "lockUntil",
+                "-lockUntil",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "where",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/UsersQueryOperations",
+                    },
+                    {
+                      "$ref": "#/components/schemas/UsersQueryOperationsAnd",
+                    },
+                    {
+                      "$ref": "#/components/schemas/UsersQueryOperationsOr",
+                    },
+                  ],
+                },
+              ],
+            },
+            "style": "deepObject",
+          },
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UsersListResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Retrieve a list of users",
+        "tags": [
+          "users",
+        ],
+      },
+      "post": {
+        "operationId": "createUsers",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersRequestBody",
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewUsersResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Create a new users",
+        "tags": [
+          "users",
+        ],
+      },
+    },
+    "/api/users/{id}": {
+      "delete": {
+        "operationId": "deleteUsers",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UsersResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/UsersNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Delete a users",
+        "tags": [
+          "users",
+        ],
+      },
+      "get": {
+        "operationId": "findUsersById",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UsersResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/UsersNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Find a users by ID",
+        "tags": [
+          "users",
+        ],
+      },
+      "parameters": [
+        {
+          "in": "query",
+          "name": "depth",
+          "schema": {
+            "type": "number",
+          },
+        },
+        {
+          "in": "query",
+          "name": "locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "fallback-locale",
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "ID of the users",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+      "patch": {
+        "operationId": "updateUsers",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersPatchRequestBody",
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UsersResponse",
+          },
+          "404": {
+            "$ref": "#/components/responses/UsersNotFoundResponse",
+          },
+        },
+        "security": [
+          {
+            "ApiKey": [],
+          },
+        ],
+        "summary": "Update a users",
+        "tags": [
+          "users",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "https//localhost",
+    },
+  ],
+}
+`;

--- a/test/openapi-generators.test.ts
+++ b/test/openapi-generators.test.ts
@@ -1,4 +1,5 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { sqliteAdapter } from '@payloadcms/db-sqlite'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import mongoose from 'mongoose'
@@ -23,10 +24,9 @@ describe('openapi generators', () => {
   })
 
   const buildPayload = async (
-    inputConfig: Omit<Config, 'db' | 'secret' | 'typescript'>,
+    inputConfig: Omit<Config, 'db' | 'secret' | 'typescript'> & Partial<Config>,
   ): Promise<Payload> => {
     const config = await buildConfig({
-      ...inputConfig,
       db: mongooseAdapter({
         url: mongo.getUri(),
       }),
@@ -34,6 +34,7 @@ describe('openapi generators', () => {
       typescript: {
         autoGenerate: false,
       },
+      ...inputConfig,
     })
 
     return await new BasePayload().init({ config })
@@ -199,4 +200,27 @@ describe('openapi generators', () => {
 
     expect(spec).toMatchSnapshot()
   })
+
+  test('respects default ID type from db adapter', async () => {
+    const payload = await buildPayload({
+      // SQLite uses numbers for IDs
+      db: sqliteAdapter({
+        client: { url: ':memory:', },
+      }),
+      collections: [Posts]
+    })
+
+    const spec = await generateV30Spec(
+      { protocol: 'https', headers: new Headers({ host: 'localhost' }), payload },
+      {
+        openapiVersion: '3.0',
+        authEndpoint: '/api/auth',
+        metadata: { title: 'Test API', version: '1.0' },
+      },
+    )
+
+    expect(spec).toMatchSnapshot()
+    expect((spec as any).components?.schemas?.Post?.properties?.id?.type).toBe('number')
+  })
+
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,11 @@
   dependencies:
     tslib "^2.0.0"
 
+"@drizzle-team/brocli@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@drizzle-team/brocli/-/brocli-0.10.2.tgz#9757c006a43daaa6f45512e6cf5fabed36fb9da7"
+  integrity sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==
+
 "@emnapi/runtime@^1.4.4":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.4.5.tgz#c67710d0661070f38418b6474584f159de38aba9"
@@ -290,10 +295,31 @@
   resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
 
+"@esbuild-kit/core-utils@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz#186b6598a5066f0413471d7c4d45828e399ba96c"
+  integrity sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==
+  dependencies:
+    esbuild "~0.18.20"
+    source-map-support "^0.5.21"
+
+"@esbuild-kit/esm-loader@^2.5.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz#6eedee46095d7d13b1efc381e2211ed1c60e64ea"
+  integrity sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==
+  dependencies:
+    "@esbuild-kit/core-utils" "^3.3.2"
+    get-tsconfig "^4.7.0"
+
 "@esbuild/aix-ppc64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz#51299374de171dbd80bb7d838e1cfce9af36f353"
   integrity sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==
+
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
 
 "@esbuild/aix-ppc64@0.25.2":
   version "0.25.2"
@@ -305,10 +331,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz#bef96351f16520055c947aba28802eede3c9e9a9"
   integrity sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==
 
+"@esbuild/android-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
+  integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+
 "@esbuild/android-arm64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz#58565291a1fe548638adb9c584237449e5e14018"
   integrity sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==
+
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
 
 "@esbuild/android-arm64@0.25.2":
   version "0.25.2"
@@ -320,10 +356,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz#d2e70be7d51a529425422091e0dcb90374c1546c"
   integrity sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==
 
+"@esbuild/android-arm@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
+  integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
+
 "@esbuild/android-arm@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.23.1.tgz#5eb8c652d4c82a2421e3395b808e6d9c42c862ee"
   integrity sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==
+
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
 
 "@esbuild/android-arm@0.25.2":
   version "0.25.2"
@@ -335,10 +381,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.9.tgz#d2a753fe2a4c73b79437d0ba1480e2d760097419"
   integrity sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==
 
+"@esbuild/android-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
+  integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+
 "@esbuild/android-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.23.1.tgz#ae19d665d2f06f0f48a6ac9a224b3f672e65d517"
   integrity sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==
+
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
 
 "@esbuild/android-x64@0.25.2":
   version "0.25.2"
@@ -350,10 +406,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.9.tgz#5278836e3c7ae75761626962f902a0d55352e683"
   integrity sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==
 
+"@esbuild/darwin-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
+  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+
 "@esbuild/darwin-arm64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz#05b17f91a87e557b468a9c75e9d85ab10c121b16"
   integrity sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==
+
+"@esbuild/darwin-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz#6af6bb1d05887dac515de1b162b59dc71212ed76"
+  integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
 
 "@esbuild/darwin-arm64@0.25.2":
   version "0.25.2"
@@ -365,10 +431,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz#f1513eaf9ec8fa15dcaf4c341b0f005d3e8b47ae"
   integrity sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==
 
+"@esbuild/darwin-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
+  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+
 "@esbuild/darwin-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz#c58353b982f4e04f0d022284b8ba2733f5ff0931"
   integrity sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==
+
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
 
 "@esbuild/darwin-x64@0.25.2":
   version "0.25.2"
@@ -380,10 +456,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz#e27dbc3b507b3a1cea3b9280a04b8b6b725f82be"
   integrity sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==
 
+"@esbuild/freebsd-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
+  integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
+
 "@esbuild/freebsd-arm64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz#f9220dc65f80f03635e1ef96cfad5da1f446f3bc"
   integrity sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==
+
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
 
 "@esbuild/freebsd-arm64@0.25.2":
   version "0.25.2"
@@ -395,10 +481,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz#364e3e5b7a1fd45d92be08c6cc5d890ca75908ca"
   integrity sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==
 
+"@esbuild/freebsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
+  integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+
 "@esbuild/freebsd-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz#69bd8511fa013b59f0226d1609ac43f7ce489730"
   integrity sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==
+
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
 
 "@esbuild/freebsd-x64@0.25.2":
   version "0.25.2"
@@ -410,10 +506,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz#7c869b45faeb3df668e19ace07335a0711ec56ab"
   integrity sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==
 
+"@esbuild/linux-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
+  integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
+
 "@esbuild/linux-arm64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz#8050af6d51ddb388c75653ef9871f5ccd8f12383"
   integrity sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==
+
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
 
 "@esbuild/linux-arm64@0.25.2":
   version "0.25.2"
@@ -425,10 +531,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz#48d42861758c940b61abea43ba9a29b186d6cb8b"
   integrity sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==
 
+"@esbuild/linux-arm@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
+  integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+
 "@esbuild/linux-arm@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz#ecaabd1c23b701070484990db9a82f382f99e771"
   integrity sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==
+
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
 
 "@esbuild/linux-arm@0.25.2":
   version "0.25.2"
@@ -440,10 +556,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz#6ce4b9cabf148274101701d112b89dc67cc52f37"
   integrity sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==
 
+"@esbuild/linux-ia32@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
+  integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
+
 "@esbuild/linux-ia32@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz#3ed2273214178109741c09bd0687098a0243b333"
   integrity sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==
+
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
 
 "@esbuild/linux-ia32@0.25.2":
   version "0.25.2"
@@ -455,10 +581,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz#207e54899b79cac9c26c323fc1caa32e3143f1c4"
   integrity sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==
 
+"@esbuild/linux-loong64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
+  integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+
 "@esbuild/linux-loong64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz#a0fdf440b5485c81b0fbb316b08933d217f5d3ac"
   integrity sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==
+
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
 
 "@esbuild/linux-loong64@0.25.2":
   version "0.25.2"
@@ -470,10 +606,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz#0ba48a127159a8f6abb5827f21198b999ffd1fc0"
   integrity sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==
 
+"@esbuild/linux-mips64el@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
+  integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
+
 "@esbuild/linux-mips64el@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz#e11a2806346db8375b18f5e104c5a9d4e81807f6"
   integrity sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==
+
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
 
 "@esbuild/linux-mips64el@0.25.2":
   version "0.25.2"
@@ -485,10 +631,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz#a4d4cc693d185f66a6afde94f772b38ce5d64eb5"
   integrity sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==
 
+"@esbuild/linux-ppc64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
+  integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+
 "@esbuild/linux-ppc64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz#06a2744c5eaf562b1a90937855b4d6cf7c75ec96"
   integrity sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==
+
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
 
 "@esbuild/linux-ppc64@0.25.2":
   version "0.25.2"
@@ -500,10 +656,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz#0f5805c1c6d6435a1dafdc043cb07a19050357db"
   integrity sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==
 
+"@esbuild/linux-riscv64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
+  integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
+
 "@esbuild/linux-riscv64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz#65b46a2892fc0d1af4ba342af3fe0fa4a8fe08e7"
   integrity sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==
+
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
 
 "@esbuild/linux-riscv64@0.25.2":
   version "0.25.2"
@@ -515,10 +681,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz#6776edece0f8fca79f3386398b5183ff2a827547"
   integrity sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==
 
+"@esbuild/linux-s390x@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
+  integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+
 "@esbuild/linux-s390x@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz#e71ea18c70c3f604e241d16e4e5ab193a9785d6f"
   integrity sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==
+
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
 
 "@esbuild/linux-s390x@0.25.2":
   version "0.25.2"
@@ -530,10 +706,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz#3f6f29ef036938447c2218d309dc875225861830"
   integrity sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==
 
+"@esbuild/linux-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
+  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
+
 "@esbuild/linux-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz#d47f97391e80690d4dfe811a2e7d6927ad9eed24"
   integrity sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==
+
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
 
 "@esbuild/linux-x64@0.25.2":
   version "0.25.2"
@@ -545,6 +731,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz#831fe0b0e1a80a8b8391224ea2377d5520e1527f"
   integrity sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==
 
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
+
 "@esbuild/netbsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz#744affd3b8d8236b08c5210d828b0698a62c58ac"
@@ -555,10 +746,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz#06f99d7eebe035fbbe43de01c9d7e98d2a0aa548"
   integrity sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==
 
+"@esbuild/netbsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
+  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+
 "@esbuild/netbsd-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz#44e743c9778d57a8ace4b72f3c6b839a3b74a653"
   integrity sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==
+
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
 
 "@esbuild/netbsd-x64@0.25.2":
   version "0.25.2"
@@ -575,6 +776,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz#05c5a1faf67b9881834758c69f3e51b7dee015d7"
   integrity sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==
 
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
+
 "@esbuild/openbsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz#f9caf987e3e0570500832b487ce3039ca648ce9f"
@@ -585,10 +791,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz#afb886c867e36f9d86bb21e878e1185f5d5a0935"
   integrity sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==
 
+"@esbuild/openbsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
+  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
+
 "@esbuild/openbsd-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz#2e58ae511bacf67d19f9f2dcd9e8c5a93f00c273"
   integrity sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==
+
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
 
 "@esbuild/openbsd-x64@0.25.2":
   version "0.25.2"
@@ -600,15 +816,30 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz#30855c9f8381fac6a0ef5b5f31ac6e7108a66ecf"
   integrity sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==
 
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
+
 "@esbuild/openharmony-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz#2f2144af31e67adc2a8e3705c20c2bd97bd88314"
   integrity sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==
 
+"@esbuild/sunos-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
+  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+
 "@esbuild/sunos-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz#adb022b959d18d3389ac70769cef5a03d3abd403"
   integrity sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==
+
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
 
 "@esbuild/sunos-x64@0.25.2":
   version "0.25.2"
@@ -620,10 +851,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz#69b99a9b5bd226c9eb9c6a73f990fddd497d732e"
   integrity sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==
 
+"@esbuild/win32-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
+  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
+
 "@esbuild/win32-arm64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz#84906f50c212b72ec360f48461d43202f4c8b9a2"
   integrity sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==
+
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
 
 "@esbuild/win32-arm64@0.25.2":
   version "0.25.2"
@@ -635,10 +876,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz#d789330a712af916c88325f4ffe465f885719c6b"
   integrity sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==
 
+"@esbuild/win32-ia32@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
+  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
+
 "@esbuild/win32-ia32@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz#5e3eacc515820ff729e90d0cb463183128e82fac"
   integrity sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==
+
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
 
 "@esbuild/win32-ia32@0.25.2":
   version "0.25.2"
@@ -650,10 +901,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz#52fc735406bd49688253e74e4e837ac2ba0789e3"
   integrity sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==
 
+"@esbuild/win32-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
+  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+
 "@esbuild/win32-x64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz#81fd50d11e2c32b2d6241470e3185b70c7b30699"
   integrity sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==
+
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
 "@esbuild/win32-x64@0.25.2":
   version "0.25.2"
@@ -1108,6 +1369,82 @@
     "@lexical/selection" "0.28.0"
     lexical "0.28.0"
 
+"@libsql/client@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@libsql/client/-/client-0.14.0.tgz#df30cfb21e84797398afdd268e153cf1594c68a1"
+  integrity sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==
+  dependencies:
+    "@libsql/core" "^0.14.0"
+    "@libsql/hrana-client" "^0.7.0"
+    js-base64 "^3.7.5"
+    libsql "^0.4.4"
+    promise-limit "^2.7.0"
+
+"@libsql/core@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@libsql/core/-/core-0.14.0.tgz#bbdbdf89227f1325b79e49d00babace81a47bf23"
+  integrity sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q==
+  dependencies:
+    js-base64 "^3.7.5"
+
+"@libsql/darwin-arm64@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/darwin-arm64/-/darwin-arm64-0.4.7.tgz#070679b082ff88ad0a8c8fef94c6d0cc644e441f"
+  integrity sha512-yOL742IfWUlUevnI5PdnIT4fryY3LYTdLm56bnY0wXBw7dhFcnjuA7jrH3oSVz2mjZTHujxoITgAE7V6Z+eAbg==
+
+"@libsql/darwin-x64@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/darwin-x64/-/darwin-x64-0.4.7.tgz#ee5cff8527777eea72e2ad9a4f1c41d6a5b6736e"
+  integrity sha512-ezc7V75+eoyyH07BO9tIyJdqXXcRfZMbKcLCeF8+qWK5nP8wWuMcfOVywecsXGRbT99zc5eNra4NEx6z5PkSsA==
+
+"@libsql/hrana-client@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@libsql/hrana-client/-/hrana-client-0.7.0.tgz#c059d8106b9d40dd931217333710aff2ceb5216e"
+  integrity sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==
+  dependencies:
+    "@libsql/isomorphic-fetch" "^0.3.1"
+    "@libsql/isomorphic-ws" "^0.1.5"
+    js-base64 "^3.7.5"
+    node-fetch "^3.3.2"
+
+"@libsql/isomorphic-fetch@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz#42023816d5645a5a3f3a78bb3899bdc5814c7b88"
+  integrity sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==
+
+"@libsql/isomorphic-ws@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz#e2d1faf965ba0f3be9301fbf5640164d03c4e606"
+  integrity sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==
+  dependencies:
+    "@types/ws" "^8.5.4"
+    ws "^8.13.0"
+
+"@libsql/linux-arm64-gnu@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.4.7.tgz#d1364f51b8c5a013822257de1a51525b602ac71d"
+  integrity sha512-WlX2VYB5diM4kFfNaYcyhw5y+UJAI3xcMkEUJZPtRDEIu85SsSFrQ+gvoKfcVh76B//ztSeEX2wl9yrjF7BBCA==
+
+"@libsql/linux-arm64-musl@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.4.7.tgz#14d9762853368e77e24774b306dea7c6ac2b4881"
+  integrity sha512-6kK9xAArVRlTCpWeqnNMCoXW1pe7WITI378n4NpvU5EJ0Ok3aNTIC2nRPRjhro90QcnmLL1jPcrVwO4WD1U0xw==
+
+"@libsql/linux-x64-gnu@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.4.7.tgz#ae98f4311b45ffe6c6e31241b7d321cc24cf2922"
+  integrity sha512-CMnNRCmlWQqqzlTw6NeaZXzLWI8bydaXDke63JTUCvu8R+fj/ENsLrVBtPDlxQ0wGsYdXGlrUCH8Qi9gJep0yQ==
+
+"@libsql/linux-x64-musl@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/linux-x64-musl/-/linux-x64-musl-0.4.7.tgz#9340d4c46e77ae072968e7dc70710dedfd6ee4f4"
+  integrity sha512-nI6tpS1t6WzGAt1Kx1n1HsvtBbZ+jHn0m7ogNNT6pQHZQj7AFFTIMeDQw/i/Nt5H38np1GVRNsFe99eSIMs9XA==
+
+"@libsql/win32-x64-msvc@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.4.7.tgz#b39cc6de4af797af736e9f2179002e8ebf4d2d4a"
+  integrity sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw==
+
 "@monaco-editor/loader@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.5.0.tgz#dcdbc7fe7e905690fb449bed1c251769f325c55d"
@@ -1128,6 +1465,11 @@
   integrity sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@neon-rs/load@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@neon-rs/load/-/load-0.0.4.tgz#2a2a3292c6f1fef043f49886712d3c96a547532e"
+  integrity sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==
 
 "@next/env@15.5.0":
   version "15.5.0"
@@ -1197,6 +1539,32 @@
     mongoose-paginate-v2 "1.8.5"
     prompts "2.4.2"
     uuid "10.0.0"
+
+"@payloadcms/db-sqlite@^3.58.0":
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/@payloadcms/db-sqlite/-/db-sqlite-3.58.0.tgz#0e3113c32391945edbff5eee19832361b05d96e9"
+  integrity sha512-G5NDOnPe1EOApjvdznKz1/gShwE56sMrllwjc2q7RpIaKouznxX/oHzHdI38rUSsewy8pfLFjhdPlgnPkBSLMA==
+  dependencies:
+    "@libsql/client" "0.14.0"
+    "@payloadcms/drizzle" "3.58.0"
+    console-table-printer "2.12.1"
+    drizzle-kit "0.31.4"
+    drizzle-orm "0.44.2"
+    prompts "2.4.2"
+    to-snake-case "1.0.0"
+    uuid "9.0.0"
+
+"@payloadcms/drizzle@3.58.0":
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/@payloadcms/drizzle/-/drizzle-3.58.0.tgz#38829d141356844ab27396783419c0f9ea803125"
+  integrity sha512-rY9NpbHJz30AuV++9eiM/PUwnwGm+2EsA1HkgltgcDg7Ej5YS5/gk+gbHKWDd8RpGSwdVvSmr5+8thyV9Hh/6Q==
+  dependencies:
+    console-table-printer "2.12.1"
+    dequal "2.0.3"
+    drizzle-orm "0.44.2"
+    prompts "2.4.2"
+    to-snake-case "1.0.0"
+    uuid "9.0.0"
 
 "@payloadcms/graphql@3.53.0":
   version "3.53.0"
@@ -1564,6 +1932,13 @@
   integrity sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==
   dependencies:
     "@types/webidl-conversions" "*"
+
+"@types/ws@^8.5.4":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@vitest/expect@3.2.4":
   version "3.2.4"
@@ -2166,6 +2541,11 @@ csstype@3.1.3, csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 dataloader@2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.3.tgz#42d10b4913515f5b37c6acedcb4960d6ae1b1517"
@@ -2256,6 +2636,11 @@ dequal@2.0.3, dequal@^2.0.0:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
+detect-libc@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
 detect-libc@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.4.tgz#f04715b8ba815e53b4d8109655b6508a6865a7e8"
@@ -2280,6 +2665,21 @@ dotenv@^17.2.1:
   version "17.2.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.1.tgz#6f32e10faf014883515538dc922a0fb8765d9b32"
   integrity sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==
+
+drizzle-kit@0.31.4:
+  version "0.31.4"
+  resolved "https://registry.yarnpkg.com/drizzle-kit/-/drizzle-kit-0.31.4.tgz#b4a23fae0ab8d64b262184aaf07f8cbdc2222751"
+  integrity sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==
+  dependencies:
+    "@drizzle-team/brocli" "^0.10.2"
+    "@esbuild-kit/esm-loader" "^2.5.5"
+    esbuild "^0.25.4"
+    esbuild-register "^3.5.0"
+
+drizzle-orm@0.44.2:
+  version "0.44.2"
+  resolved "https://registry.yarnpkg.com/drizzle-orm/-/drizzle-orm-0.44.2.tgz#f07658fa000e333070727f810175987295647d14"
+  integrity sha512-zGAqBzWWkVSFjZpwPOrmCrgO++1kZ5H/rZ4qTGeGOe18iXGVJWf3WPfHOVwFIbmi8kHjfJstC6rJomzGx8g/dQ==
 
 electron-to-chromium@^1.5.204:
   version "1.5.209"
@@ -2335,6 +2735,13 @@ es-module-lexer@^1.7.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
+esbuild-register@^3.5.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.6.0.tgz#cf270cfa677baebbc0010ac024b823cbf723a36d"
+  integrity sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==
+  dependencies:
+    debug "^4.3.4"
+
 esbuild@^0.25.0:
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.2.tgz#55a1d9ebcb3aa2f95e8bba9e900c1a5061bc168b"
@@ -2365,6 +2772,66 @@ esbuild@^0.25.0:
     "@esbuild/win32-arm64" "0.25.2"
     "@esbuild/win32-ia32" "0.25.2"
     "@esbuild/win32-x64" "0.25.2"
+
+esbuild@^0.25.4:
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.10.tgz#37f5aa5cd14500f141be121c01b096ca83ac34a9"
+  integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.10"
+    "@esbuild/android-arm" "0.25.10"
+    "@esbuild/android-arm64" "0.25.10"
+    "@esbuild/android-x64" "0.25.10"
+    "@esbuild/darwin-arm64" "0.25.10"
+    "@esbuild/darwin-x64" "0.25.10"
+    "@esbuild/freebsd-arm64" "0.25.10"
+    "@esbuild/freebsd-x64" "0.25.10"
+    "@esbuild/linux-arm" "0.25.10"
+    "@esbuild/linux-arm64" "0.25.10"
+    "@esbuild/linux-ia32" "0.25.10"
+    "@esbuild/linux-loong64" "0.25.10"
+    "@esbuild/linux-mips64el" "0.25.10"
+    "@esbuild/linux-ppc64" "0.25.10"
+    "@esbuild/linux-riscv64" "0.25.10"
+    "@esbuild/linux-s390x" "0.25.10"
+    "@esbuild/linux-x64" "0.25.10"
+    "@esbuild/netbsd-arm64" "0.25.10"
+    "@esbuild/netbsd-x64" "0.25.10"
+    "@esbuild/openbsd-arm64" "0.25.10"
+    "@esbuild/openbsd-x64" "0.25.10"
+    "@esbuild/openharmony-arm64" "0.25.10"
+    "@esbuild/sunos-x64" "0.25.10"
+    "@esbuild/win32-arm64" "0.25.10"
+    "@esbuild/win32-ia32" "0.25.10"
+    "@esbuild/win32-x64" "0.25.10"
+
+esbuild@~0.18.20:
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
+  integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.18.20"
+    "@esbuild/android-arm64" "0.18.20"
+    "@esbuild/android-x64" "0.18.20"
+    "@esbuild/darwin-arm64" "0.18.20"
+    "@esbuild/darwin-x64" "0.18.20"
+    "@esbuild/freebsd-arm64" "0.18.20"
+    "@esbuild/freebsd-x64" "0.18.20"
+    "@esbuild/linux-arm" "0.18.20"
+    "@esbuild/linux-arm64" "0.18.20"
+    "@esbuild/linux-ia32" "0.18.20"
+    "@esbuild/linux-loong64" "0.18.20"
+    "@esbuild/linux-mips64el" "0.18.20"
+    "@esbuild/linux-ppc64" "0.18.20"
+    "@esbuild/linux-riscv64" "0.18.20"
+    "@esbuild/linux-s390x" "0.18.20"
+    "@esbuild/linux-x64" "0.18.20"
+    "@esbuild/netbsd-x64" "0.18.20"
+    "@esbuild/openbsd-x64" "0.18.20"
+    "@esbuild/sunos-x64" "0.18.20"
+    "@esbuild/win32-arm64" "0.18.20"
+    "@esbuild/win32-ia32" "0.18.20"
+    "@esbuild/win32-x64" "0.18.20"
 
 esbuild@~0.23.0:
   version "0.23.1"
@@ -2558,6 +3025,14 @@ fdir@^6.4.4, fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-type@19.3.0:
   version "19.3.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-19.3.0.tgz#7b5989c4af05e4b02c553f29a6acca0508e9ea9b"
@@ -2615,6 +3090,13 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -2655,6 +3137,13 @@ get-tsconfig@4.8.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.8.1.tgz#8995eb391ae6e1638d251118c7b56de7eb425471"
   integrity sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
+get-tsconfig@^4.7.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
+  integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -3005,6 +3494,11 @@ joycon@^3.1.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
+js-base64@^3.7.5:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.8.tgz#af44496bc09fa178ed9c4adf67eb2b46f5c6d2a4"
+  integrity sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3078,6 +3572,22 @@ lexical@0.28.0:
   version "0.28.0"
   resolved "https://registry.yarnpkg.com/lexical/-/lexical-0.28.0.tgz#e9a285a7a6d5bf1717fecc73802ee61ea9ac8eb4"
   integrity sha512-dLE3O1PZg0TlZxRQo9YDpjCjDUj8zluGyBO9MHdjo21qZmMUNrxQPeCRt8fn2s5l4HKYFQ1YNgl7k1pOJB/vZQ==
+
+libsql@^0.4.4:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/libsql/-/libsql-0.4.7.tgz#dc80f94c58ac8146adc351e82f76dd12366fe051"
+  integrity sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==
+  dependencies:
+    "@neon-rs/load" "^0.0.4"
+    detect-libc "2.0.2"
+  optionalDependencies:
+    "@libsql/darwin-arm64" "0.4.7"
+    "@libsql/darwin-x64" "0.4.7"
+    "@libsql/linux-arm64-gnu" "0.4.7"
+    "@libsql/linux-arm64-musl" "0.4.7"
+    "@libsql/linux-x64-gnu" "0.4.7"
+    "@libsql/linux-x64-musl" "0.4.7"
+    "@libsql/win32-x64-msvc" "0.4.7"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -3629,6 +4139,20 @@ next@^15.5.0:
     "@next/swc-win32-x64-msvc" "15.5.0"
     sharp "^0.34.3"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
+
 node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
@@ -3948,6 +4472,11 @@ process-warning@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-4.0.1.tgz#5c1db66007c67c756e4e09eb170cdece15da32fb"
   integrity sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==
+
+promise-limit@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/promise-limit/-/promise-limit-2.7.0.tgz#eb5737c33342a030eaeaecea9b3d3a93cb592b26"
+  integrity sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==
 
 prompts@2.4.2:
   version "2.4.2"
@@ -4319,7 +4848,7 @@ sonner@^1.7.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map-support@~0.5.20:
+source-map-support@^0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -4547,12 +5076,31 @@ tinyspy@^4.0.3:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.3.tgz#d1d0f0602f4c15f1aae083a34d6d0df3363b1b52"
   integrity sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==
 
+to-no-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/to-no-case/-/to-no-case-1.0.2.tgz#c722907164ef6b178132c8e69930212d1b4aa16a"
+  integrity sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+to-snake-case@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-snake-case/-/to-snake-case-1.0.0.tgz#ce746913897946019a87e62edfaeaea4c608ab8c"
+  integrity sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==
+  dependencies:
+    to-space-case "^1.0.0"
+
+to-space-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-space-case/-/to-space-case-1.0.0.tgz#b052daafb1b2b29dc770cea0163e5ec0ebc9fc17"
+  integrity sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==
+  dependencies:
+    to-no-case "^1.0.0"
 
 token-types@^6.0.0:
   version "6.0.0"
@@ -4703,6 +5251,11 @@ uuid@10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
+uuid@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
@@ -4772,6 +5325,11 @@ watchpack@^2.4.1:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
@@ -4861,6 +5419,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.13.0:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@^8.16.0:
   version "8.18.1"


### PR DESCRIPTION
Hello! First of all, thank you for developing this library.

When using this library with SQLite, I found a issue where the generated OpenAPI schema specifies `id` as a string when it should be number. After digging into Payload's source code, it seems that the `id` field type should be determined by the DB adapter by default, e.g.:
https://github.com/payloadcms/payload/blob/main/packages/payload/src/bin/generateTypes.ts#L32

This PR updates the relevant calls to `entityToJSONSchema` to use `config.db.defaultIDType` as the default ID type, which corrects the type of `id` fields. I have also added a test case using the sqlite adapter to demonstrate this.

Thanks for your time to review this!